### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.13.0](https://github.com/hseeberger/pub-sub-client/compare/v0.12.0...v0.13.0) - 2026-06-13
+
+### Fixed
+
+- change-compromised-key ([#20](https://github.com/hseeberger/pub-sub-client/pull/20))
+
+### Other
+
+- improve README
+- big cleanup and update ([#26](https://github.com/hseeberger/pub-sub-client/pull/26))
+- cleanup logging related code ([#19](https://github.com/hseeberger/pub-sub-client/pull/19))
+- bump version to v0.12.1-alpha


### PR DESCRIPTION



## 🤖 New release

* `pub-sub-client`: 0.12.0 -> 0.13.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.0](https://github.com/hseeberger/pub-sub-client/compare/v0.12.0...v0.13.0) - 2026-06-13

### Fixed

- change-compromised-key ([#20](https://github.com/hseeberger/pub-sub-client/pull/20))

### Other

- improve README
- big cleanup and update ([#26](https://github.com/hseeberger/pub-sub-client/pull/26))
- cleanup logging related code ([#19](https://github.com/hseeberger/pub-sub-client/pull/19))
- bump version to v0.12.1-alpha
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).