### PR TITLE
build(deps): patch RUSTSEC-2026-0185/-0190 (quinn-proto, anyhow)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -1651,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Bumps two transitive dependencies flagged by `cargo-audit`, which is currently
failing the **Security Audit** check (including on release PR #45):

- `quinn-proto` 0.11.14 → 0.11.15 — **RUSTSEC-2026-0185** (critical DoS: remote
  memory exhaustion from unbounded out-of-order stream reassembly)
- `anyhow` 1.0.102 → 1.0.103 — **RUSTSEC-2026-0190** (unsound `Error::downcast_mut`)

`Cargo.lock`-only change; both bumps are semver-compatible and `cargo check` passes.
Landing this on `main` lets release-plz regenerate #45 with a clean lockfile so the
v0.13.2 release can merge.