### PR TITLE
chore: standardize project scaffolding and package metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
-.claude
 .DS_Store
+.claude
 .envrc.local
 .vscode
 .zed
 target
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name          = "pub-sub-client"
-version       = "0.13.2"
-edition       = "2024"
-description   = "Google Cloud Pub/Sub client library"
-authors       = [ "Heiko Seeberger <git@heikoseeberger.de>" ]
-license       = "Apache-2.0"
-readme        = "README.md"
-homepage      = "https://github.com/hseeberger/pub-sub-client"
-repository    = "https://github.com/hseeberger/pub-sub-client"
-documentation = "https://github.com/hseeberger/pub-sub-client"
-include       = [
+name = "pub-sub-client"
+description = "Google Cloud Pub/Sub client library"
+version = "0.13.2"
+edition = "2024"
+license = "Apache-2.0"
+readme = "README.md"
+homepage = "https://github.com/hseeberger/pub-sub-client"
+repository = "https://github.com/hseeberger/pub-sub-client"
+documentation = "https://docs.rs/pub-sub-client/latest/pub_sub_client/"
+include = [
     "src/**/*.rs",
     "Cargo.toml",
     "LICENSE",
     "README.md",
 ]
+publish = true
 
 [dependencies]
 base64     = { version = "0.22" }

--- a/justfile
+++ b/justfile
@@ -3,27 +3,28 @@ set shell := ["bash", "-uc"]
 nightly := `rustc --version | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | sed 's/^/nightly-/'`
 
 check:
-	cargo check --tests
+    cargo check --tests
 
 fix:
-	cargo fix --tests --allow-dirty --allow-staged
+    cargo fix --tests --allow-dirty --allow-staged
 
 fmt:
-    cargo +{{nightly}} fmt
+    cargo +{{ nightly }} fmt
+    RUST_LOG=error taplo fmt
 
 fmt-check:
-    cargo +{{nightly}} fmt --check
+    cargo +{{ nightly }} fmt --check
 
 lint:
-	cargo clippy --tests --no-deps -- -D warnings
+    cargo clippy --tests --no-deps -- -D warnings
 
 lint-fix:
-	cargo clippy --tests --no-deps --allow-dirty --allow-staged --fix
+    cargo clippy --tests --no-deps --allow-dirty --allow-staged --fix
 
 test:
-	cargo test --tests
+    cargo test --tests
 
 doc:
-	cargo doc --no-deps
+    cargo doc --no-deps
 
 all: check fmt lint test doc


### PR DESCRIPTION
Standardize scaffolding, CI config, and package metadata to the shared template.

- `justfile`: 4-space indentation, `taplo fmt` in the `fmt` recipe
- `.gitignore`: canonical entries, sorted
- `Cargo.toml`: SPDX license, no `authors`, docs.rs `documentation`, consistent field order, explicit `publish`
- workflows / rustfmt edition aligned where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)