### PR TITLE
docs: turn on warnings for missing docs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,9 @@ pub enum Error {
     /// malformed.
     #[error("initialization error: {reason}")]
     Initialization {
+        /// Human-readable reason for the failure.
         reason: String,
+        /// The underlying error that caused the failure.
         source: Box<dyn StdError + Send + Sync + 'static>,
     },
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 //!
 //! All operations are provided by [`PubSubClient`].
 
+#![warn(missing_docs)]
+
 mod error;
 mod manager;
 mod publisher;

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -47,8 +47,11 @@ where
 #[derive(Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RawPublishedMessage<'a> {
+    /// The already Base64 encoded message data.
     pub data: Option<String>,
+    /// Optional attributes attached to the message.
     pub attributes: Option<HashMap<String, String>>,
+    /// Optional key by which Pub/Sub orders messages.
     pub ordering_key: Option<&'a str>,
 }
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -14,12 +14,19 @@ pub struct PulledMessage<M>
 where
     M: DeserializeOwned,
 {
+    /// ID used to acknowledge the message.
     pub ack_id: String,
+    /// The deserialized domain message, or the [`Error`] that occurred while decoding it.
     pub message: Result<M, Error>,
+    /// Optional attributes attached to the message.
     pub attributes: Option<HashMap<String, String>>,
+    /// Unique ID assigned to the message by Pub/Sub.
     pub id: String,
+    /// Time at which the message was published.
     pub publish_time: OffsetDateTime,
+    /// Key by which Pub/Sub orders messages, if any.
     pub ordering_key: Option<String>,
+    /// Number of times delivery of the message has been attempted.
     pub delivery_attempt: u32,
 }
 
@@ -28,8 +35,11 @@ where
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RawPulledMessageEnvelope {
+    /// ID used to acknowledge the message.
     pub ack_id: String,
+    /// The raw pulled message.
     pub message: RawPulledMessage,
+    /// Number of times delivery of the message has been attempted.
     #[serde(default)] // The Pub/Sub emulator does not send this field!
     pub delivery_attempt: u32,
 }
@@ -38,12 +48,17 @@ pub struct RawPulledMessageEnvelope {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RawPulledMessage {
+    /// The still Base64 encoded message data.
     pub data: Option<String>,
+    /// Optional attributes attached to the message.
     pub attributes: Option<HashMap<String, String>>,
+    /// Unique ID assigned to the message by Pub/Sub.
     #[serde(rename = "messageId")]
     pub id: String,
+    /// Time at which the message was published.
     #[serde(with = "time::serde::rfc3339")]
     pub publish_time: OffsetDateTime,
+    /// Key by which Pub/Sub orders messages, if any.
     pub ordering_key: Option<String>,
 }
 


### PR DESCRIPTION
Enables `#![warn(missing_docs)]` and adds doc comments for the previously-undocumented public struct fields the lint surfaced.